### PR TITLE
Fix oracle/docker-images#1729: Add GraalVM image that has `native-image` pre-installed

### DIFF
--- a/community/Dockerfile
+++ b/community/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
 #
 
-FROM oraclelinux:7-slim
+FROM oraclelinux:7-slim as graal
 
 # Note: If you are behind a web proxy, set the build variables for the build:
 #       E.g.:  docker build --build-arg "https_proxy=..." --build-arg "http_proxy=..." --build-arg "no_proxy=..." ...
@@ -36,10 +36,14 @@ RUN set -eux \
     && ln -sfT "$JAVA_HOME" /usr/java/default \
     && ln -sfT "$JAVA_HOME" /usr/java/latest \
     && for bin in "$JAVA_HOME/bin/"*; do \
-        base="$(basename "$bin")"; \
-        [ ! -e "/usr/bin/$base" ]; \
-        alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
+    base="$(basename "$bin")"; \
+    [ ! -e "/usr/bin/$base" ]; \
+    alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
     done \
     && chmod +x /usr/local/bin/gu
 
 CMD java -version
+
+## add native-image target
+FROM graal as native-image
+RUN gu install native-image

--- a/community/Dockerfile.java11
+++ b/community/Dockerfile.java11
@@ -3,7 +3,7 @@
 # Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
 #
 
-FROM oraclelinux:7-slim
+FROM oraclelinux:7-slim as graal
 
 # Note: If you are behind a web proxy, set the build variables for the build:
 #       E.g.:  docker build --build-arg "https_proxy=..." --build-arg "http_proxy=..." --build-arg "no_proxy=..." ...
@@ -39,11 +39,15 @@ RUN set -eux \
     && ln -sfT "$JAVA_HOME" /usr/java/default \
     && ln -sfT "$JAVA_HOME" /usr/java/latest \
     && for bin in "$JAVA_HOME/bin/"*; do \
-        base="$(basename "$bin")"; \
-        [ ! -e "/usr/bin/$base" ]; \
-        alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
+    base="$(basename "$bin")"; \
+    [ ! -e "/usr/bin/$base" ]; \
+    alternatives --install "/usr/bin/$base" "$base" "$bin" 20000; \
     done \
 
     && chmod +x /usr/local/bin/gu
 
 CMD java -version
+
+## add native-image target
+FROM graal as native-image
+RUN gu install native-image

--- a/community/Dockerfile.ol8
+++ b/community/Dockerfile.ol8
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
-FROM oraclelinux:8-slim
+FROM oraclelinux:8-slim as graal
 
 # Note: If you are behind a web proxy, set the build variables for the build:
 #       E.g.:  docker build --build-arg "https_proxy=..." --build-arg "http_proxy=..." --build-arg "no_proxy=..." ...
@@ -34,3 +34,7 @@ RUN set -eux && curl --fail --silent --location --retry 3 ${GRAALVM_PKG} | gunzi
     && chmod +x /usr/local/bin/gu
 
 CMD java -version
+
+## add native-image target
+FROM graal as native-image
+RUN gu install native-image

--- a/community/Dockerfile.ol8-java11
+++ b/community/Dockerfile.ol8-java11
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
-FROM oraclelinux:8-slim
+FROM oraclelinux:8-slim as graal
 
 # Note: If you are behind a web proxy, set the build variables for the build:
 #       E.g.:  docker build --build-arg "https_proxy=..." --build-arg "http_proxy=..." --build-arg "no_proxy=..." ...
@@ -41,3 +41,7 @@ RUN set -eux \
     && chmod +x /usr/local/bin/gu
 
 CMD java -version
+
+## add native-image target
+FROM graal as native-image
+RUN gu install native-image

--- a/community/README.md
+++ b/community/README.md
@@ -15,18 +15,26 @@ The images are intended for use in the **FROM** field of a downstream Dockerfile
 # Building the images
 
 For building a GraalVM Java 8 image use:
-
+### GraalVM only
+```
+docker build --build-arg GRAALVM_VERSION=<GraalVM Version> --build-arg JAVA_VERSION=java8 -t docker.pkg.github.com/graalvm/container/community:<GraalVM Version>-java8 --target graal .
+```
+### GraalVM and native-image
 ```
 docker build --build-arg GRAALVM_VERSION=<GraalVM Version> --build-arg JAVA_VERSION=java8 -t docker.pkg.github.com/graalvm/container/community:<GraalVM Version>-java8 .
 ```
 
 For building GraalVM Java 11 amd64 and arm64 images use:
-
+### GraalVM only
+```
+docker buildx build --platform linux/amd64 --build-arg GRAALVM_VERSION=<GraalVM Version> --build-arg JAVA_VERSION=java11 -t docker.pkg.github.com/graalvm/container/community:<GraalVM Version>-java11-amd64 --output=type=docker -f Dockerfile.java11 --target graal .
+docker buildx build --platform linux/arm64 --build-arg GRAALVM_VERSION=<GraalVM Version> --build-arg JAVA_VERSION=java11 -t docker.pkg.github.com/graalvm/container/community:<GraalVM Version>-java11-arm64 --output=type=docker -f Dockerfile.java11 --target graal .
+```
+### GraalVM and native-image
 ```
 docker buildx build --platform linux/amd64 --build-arg GRAALVM_VERSION=<GraalVM Version> --build-arg JAVA_VERSION=java11 -t docker.pkg.github.com/graalvm/container/community:<GraalVM Version>-java11-amd64 --output=type=docker -f Dockerfile.java11 .
 docker buildx build --platform linux/arm64 --build-arg GRAALVM_VERSION=<GraalVM Version> --build-arg JAVA_VERSION=java11 -t docker.pkg.github.com/graalvm/container/community:<GraalVM Version>-java11-arm64 --output=type=docker -f Dockerfile.java11 .
 ```
-
 # License
 The GraalVM CE Dockerfile is licensed under the [Universal Permissive License (UPL), Version 1](https://opensource.org/licenses/UPL).  This license applies to the Dockerfile only, and not to any resulting Docker image.
 


### PR DESCRIPTION
This PR aims to fix oracle/docker-images#1729 to provide support for images that has `native-image` pre-installed. it relies on docker [multi-stage build feature](https://docs.docker.com/develop/develop-images/multistage-build/#use-a-previous-stage-as-a-new-stage)