### PR TITLE
bump base image version

### DIFF
--- a/community/Dockerfile
+++ b/community/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
 #
 
-FROM oraclelinux:7-slim
+FROM oraclelinux:8-slim
 
 # Note: If you are behind a web proxy, set the build variables for the build:
 #       E.g.:  docker build --build-arg "https_proxy=..." --build-arg "http_proxy=..." --build-arg "no_proxy=..." ...


### PR DESCRIPTION
We're using `oracle/graalvm-ce:20.2.0-java8`, and recently [trivy](https://github.com/aquasecurity/trivy) started reporting a bunch security alerts. Bumping base image version should make things a bit better