### PR TITLE
Improve the README for the TruffleRuby image

### DIFF
--- a/truffleruby/README.md
+++ b/truffleruby/README.md
@@ -1,13 +1,21 @@
 
-# Truffleruby
+# TruffleRuby
 
 TruffleRuby is the [GraalVM](http://graalvm.org/) high-performance implementation of the [Ruby programming language](https://www.ruby-lang.org/en/).  
 
-# How to use these images
+## Docker images
+
+See https://github.com/graalvm/container/pkgs/container/truffleruby
+
+## How to use these images
 
 The images are intended for use in the **FROM** field of a downstream Dockerfile. For example, specify `FROM ghcr.io/graalvm/truffleruby:latest` or a version tag.
 
-# Supported tags
+## Installing system packages
+
+Use `microdnf install some-package`.
+
+## Supported tags
 
 [`GRAALVM_VERSION/ol8/ol8-GRAALVM_VERSION/latest`](https://github.com/graalvm/container/blob/master/truffleruby/Dockerfile.ol8).  
 
@@ -18,7 +26,7 @@ The images are intended for use in the **FROM** field of a downstream Dockerfile
 [`ol7-slim/ol7-slim-GRAALVM_VERSION`](https://github.com/graalvm/container/blob/master/truffleruby/Dockerfile.slim).  
 
 
-# Building the images
+## Building the images
 
 For building a Truffleruby image use:
 


### PR DESCRIPTION
So I can link to https://github.com/graalvm/container/blob/master/truffleruby/README.md
instead of https://github.com/graalvm/container/pkgs/container/truffleruby which currently has no information at all.

Please merge soon.