### PR TITLE
Use COPY instead of ADD for gu-wrapper.sh

### DIFF
--- a/community/Dockerfile.ol7-java11
+++ b/community/Dockerfile.ol7-java11
@@ -33,7 +33,7 @@ ARG TARGETPLATFORM
 ENV LANG=en_US.UTF-8 \
     JAVA_HOME=/opt/graalvm-ce-$JAVA_VERSION-$GRAALVM_VERSION
 
-ADD gu-wrapper.sh /usr/local/bin/gu
+COPY gu-wrapper.sh /usr/local/bin/gu
 RUN set -eux \
     && if [ "$TARGETPLATFORM" == "linux/amd64" ]; then GRAALVM_PKG=${GRAALVM_PKG/GRAALVM_ARCH/linux-amd64}; fi \
     && if [ "$TARGETPLATFORM" == "linux/arm64" ]; then GRAALVM_PKG=${GRAALVM_PKG/GRAALVM_ARCH/linux-aarch64}; fi \

--- a/community/Dockerfile.ol7-java17
+++ b/community/Dockerfile.ol7-java17
@@ -33,7 +33,7 @@ ARG TARGETPLATFORM
 ENV LANG=en_US.UTF-8 \
     JAVA_HOME=/opt/graalvm-ce-$JAVA_VERSION-$GRAALVM_VERSION
 
-ADD gu-wrapper.sh /usr/local/bin/gu
+COPY gu-wrapper.sh /usr/local/bin/gu
 RUN set -eux \
     && if [ "$TARGETPLATFORM" == "linux/amd64" ]; then GRAALVM_PKG=${GRAALVM_PKG/GRAALVM_ARCH/linux-amd64}; fi \
     && if [ "$TARGETPLATFORM" == "linux/arm64" ]; then GRAALVM_PKG=${GRAALVM_PKG/GRAALVM_ARCH/linux-aarch64}; fi \

--- a/community/Dockerfile.ol8-java11
+++ b/community/Dockerfile.ol8-java11
@@ -27,7 +27,7 @@ ARG TARGETPLATFORM
 ENV LANG=en_US.UTF-8 \
     JAVA_HOME=/opt/graalvm-ce-$JAVA_VERSION-$GRAALVM_VERSION
 
-ADD gu-wrapper.sh /usr/local/bin/gu
+COPY gu-wrapper.sh /usr/local/bin/gu
 RUN set -eux \
     && if [ "$TARGETPLATFORM" == "linux/amd64" ]; then GRAALVM_PKG=${GRAALVM_PKG/GRAALVM_ARCH/linux-amd64}; fi \
     && if [ "$TARGETPLATFORM" == "linux/arm64" ]; then GRAALVM_PKG=${GRAALVM_PKG/GRAALVM_ARCH/linux-aarch64}; fi \

--- a/community/Dockerfile.ol8-java17
+++ b/community/Dockerfile.ol8-java17
@@ -27,7 +27,7 @@ ARG TARGETPLATFORM
 ENV LANG=en_US.UTF-8 \
     JAVA_HOME=/opt/graalvm-ce-$JAVA_VERSION-$GRAALVM_VERSION
 
-ADD gu-wrapper.sh /usr/local/bin/gu
+COPY gu-wrapper.sh /usr/local/bin/gu
 RUN set -eux \
     && if [ "$TARGETPLATFORM" == "linux/amd64" ]; then GRAALVM_PKG=${GRAALVM_PKG/GRAALVM_ARCH/linux-amd64}; fi \
     && if [ "$TARGETPLATFORM" == "linux/arm64" ]; then GRAALVM_PKG=${GRAALVM_PKG/GRAALVM_ARCH/linux-aarch64}; fi \


### PR DESCRIPTION
According to Docker's best practices, `COPY` is [preferred](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy)

[Dockle](https://github.com/goodwithtech/dockle) also reports this as a potential vulnerability:

```
FATAL	- CIS-DI-0009: Use COPY instead of ADD in Dockerfile
	* Use COPY : ADD gu-wrapper.sh /usr/local/bin/gu # buildkit
``` 