### PR TITLE
Set correct urls for {graalpy,truffleruby}-community

### DIFF
--- a/graalpy-community/Dockerfile.debian
+++ b/graalpy-community/Dockerfile.debian
@@ -15,7 +15,7 @@ LABEL \
     org.opencontainers.image.description='GraalPy is the GraalVM high-performance implementation of the Python programming language.'
 
 ARG GRAALVM_VERSION=23.0.0
-ARG GRAALVM_PKG=https://github.com/oracle/graalpy/releases/download/vm-$GRAALVM_VERSION/graalpy-$GRAALVM_VERSION-linux-amd64.tar.gz
+ARG GRAALVM_PKG=https://github.com/oracle/graalpython/releases/download/graal-$GRAALVM_VERSION/graalpy-community-$GRAALVM_VERSION-linux-amd64.tar.gz
 
 WORKDIR /app
 

--- a/graalpy-community/Dockerfile.ol7
+++ b/graalpy-community/Dockerfile.ol7
@@ -14,7 +14,7 @@ LABEL \
     org.opencontainers.image.description='GraalPy is the GraalVM high-performance implementation of the Python programming language.'
 
 ARG GRAALVM_VERSION=23.0.0
-ARG GRAALVM_PKG=https://github.com/oracle/graalpy/releases/download/vm-$GRAALVM_VERSION/graalpy-$GRAALVM_VERSION-linux-amd64.tar.gz
+ARG GRAALVM_PKG=https://github.com/oracle/graalpython/releases/download/graal-$GRAALVM_VERSION/graalpy-community-$GRAALVM_VERSION-linux-amd64.tar.gz
 ARG TEMP_REGION=""
 
 WORKDIR /app

--- a/graalpy-community/Dockerfile.ol7-slim
+++ b/graalpy-community/Dockerfile.ol7-slim
@@ -15,7 +15,7 @@ LABEL \
     org.opencontainers.image.description='GraalPy is the GraalVM high-performance implementation of the Python programming language.'
 
 ARG GRAALVM_VERSION=23.0.0
-ARG GRAALVM_PKG=https://github.com/oracle/graalpy/releases/download/vm-$GRAALVM_VERSION/graalpy-$GRAALVM_VERSION-linux-amd64.tar.gz
+ARG GRAALVM_PKG=https://github.com/oracle/graalpython/releases/download/graal-$GRAALVM_VERSION/graalpy-community-$GRAALVM_VERSION-linux-amd64.tar.gz
 ARG TEMP_REGION=""
 
 WORKDIR /app

--- a/graalpy-community/Dockerfile.ol8
+++ b/graalpy-community/Dockerfile.ol8
@@ -15,7 +15,7 @@ LABEL \
     org.opencontainers.image.description='GraalPy is the GraalVM high-performance implementation of the Python programming language.'
 
 ARG GRAALVM_VERSION=23.0.0
-ARG GRAALVM_PKG=https://github.com/oracle/graalpy/releases/download/vm-$GRAALVM_VERSION/graalpy-$GRAALVM_VERSION-linux-amd64.tar.gz
+ARG GRAALVM_PKG=https://github.com/oracle/graalpython/releases/download/graal-$GRAALVM_VERSION/graalpy-community-$GRAALVM_VERSION-linux-amd64.tar.gz
 ARG TEMP_REGION=""
 
 WORKDIR /app

--- a/graalpy-community/Dockerfile.ol8-slim
+++ b/graalpy-community/Dockerfile.ol8-slim
@@ -15,7 +15,7 @@ LABEL \
     org.opencontainers.image.description='GraalPy is the GraalVM high-performance implementation of the Python programming language.'
 
 ARG GRAALVM_VERSION=23.0.0
-ARG GRAALVM_PKG=https://github.com/oracle/graalpy/releases/download/vm-$GRAALVM_VERSION/graalpy-$GRAALVM_VERSION-linux-amd64.tar.gz
+ARG GRAALVM_PKG=https://github.com/oracle/graalpython/releases/download/graal-$GRAALVM_VERSION/graalpy-community-$GRAALVM_VERSION-linux-amd64.tar.gz
 ARG TEMP_REGION=""
 
 WORKDIR /app

--- a/graalpy-community/Dockerfile.ol9
+++ b/graalpy-community/Dockerfile.ol9
@@ -15,7 +15,7 @@ LABEL \
     org.opencontainers.image.description='GraalPy is the GraalVM high-performance implementation of the Python programming language.'
 
 ARG GRAALVM_VERSION=23.0.0
-ARG GRAALVM_PKG=https://github.com/oracle/graalpy/releases/download/vm-$GRAALVM_VERSION/graalpy-$GRAALVM_VERSION-linux-amd64.tar.gz
+ARG GRAALVM_PKG=https://github.com/oracle/graalpython/releases/download/graal-$GRAALVM_VERSION/graalpy-community-$GRAALVM_VERSION-linux-amd64.tar.gz
 ARG TEMP_REGION=""
 
 WORKDIR /app

--- a/graalpy-community/Dockerfile.ol9-slim
+++ b/graalpy-community/Dockerfile.ol9-slim
@@ -14,7 +14,7 @@ LABEL \
     org.opencontainers.image.description='GraalPy is the GraalVM high-performance implementation of the Python programming language.'
 
 ARG GRAALVM_VERSION=23.0.0
-ARG GRAALVM_PKG=https://github.com/oracle/graalpy/releases/download/vm-$GRAALVM_VERSION/graalpy-$GRAALVM_VERSION-linux-amd64.tar.gz
+ARG GRAALVM_PKG=https://github.com/oracle/graalpython/releases/download/graal-$GRAALVM_VERSION/graalpy-community-$GRAALVM_VERSION-linux-amd64.tar.gz
 ARG TEMP_REGION=""
 
 WORKDIR /app

--- a/truffleruby-community/Dockerfile.debian
+++ b/truffleruby-community/Dockerfile.debian
@@ -16,7 +16,7 @@ LABEL \
 
 ARG GRAALVM_VERSION=23.0.0
 ARG TARGETPLATFORM
-ARG GRAALVM_PKG=https://github.com/oracle/truffleruby/releases/download/vm-$GRAALVM_VERSION/truffleruby-$GRAALVM_VERSION-GRAALVM_ARCH.tar.gz
+ARG GRAALVM_PKG=https://github.com/oracle/truffleruby/releases/download/graal-$GRAALVM_VERSION/truffleruby-community-$GRAALVM_VERSION-GRAALVM_ARCH.tar.gz
 
 WORKDIR /app
 

--- a/truffleruby-community/Dockerfile.ol7
+++ b/truffleruby-community/Dockerfile.ol7
@@ -16,7 +16,7 @@ LABEL \
 
 ARG GRAALVM_VERSION=23.0.0
 ARG TARGETPLATFORM
-ARG GRAALVM_PKG=https://github.com/oracle/truffleruby/releases/download/vm-$GRAALVM_VERSION/truffleruby-$GRAALVM_VERSION-GRAALVM_ARCH.tar.gz
+ARG GRAALVM_PKG=https://github.com/oracle/truffleruby/releases/download/graal-$GRAALVM_VERSION/truffleruby-community-$GRAALVM_VERSION-GRAALVM_ARCH.tar.gz
 ARG TEMP_REGION=""
 
 WORKDIR /app

--- a/truffleruby-community/Dockerfile.ol7-slim
+++ b/truffleruby-community/Dockerfile.ol7-slim
@@ -16,7 +16,7 @@ LABEL \
 
 ARG GRAALVM_VERSION=23.0.0
 ARG TARGETPLATFORM
-ARG GRAALVM_PKG=https://github.com/oracle/truffleruby/releases/download/vm-$GRAALVM_VERSION/truffleruby-$GRAALVM_VERSION-GRAALVM_ARCH.tar.gz
+ARG GRAALVM_PKG=https://github.com/oracle/truffleruby/releases/download/graal-$GRAALVM_VERSION/truffleruby-community-$GRAALVM_VERSION-GRAALVM_ARCH.tar.gz
 ARG TEMP_REGION=""
 
 WORKDIR /app

--- a/truffleruby-community/Dockerfile.ol8
+++ b/truffleruby-community/Dockerfile.ol8
@@ -16,7 +16,7 @@ LABEL \
 
 ARG GRAALVM_VERSION=23.0.0
 ARG TARGETPLATFORM
-ARG GRAALVM_PKG=https://github.com/oracle/truffleruby/releases/download/vm-$GRAALVM_VERSION/truffleruby-$GRAALVM_VERSION-GRAALVM_ARCH.tar.gz
+ARG GRAALVM_PKG=https://github.com/oracle/truffleruby/releases/download/graal-$GRAALVM_VERSION/truffleruby-community-$GRAALVM_VERSION-GRAALVM_ARCH.tar.gz
 ARG TEMP_REGION=""
 
 WORKDIR /app

--- a/truffleruby-community/Dockerfile.ol8-slim
+++ b/truffleruby-community/Dockerfile.ol8-slim
@@ -16,7 +16,7 @@ LABEL \
 
 ARG GRAALVM_VERSION=23.0.0
 ARG TARGETPLATFORM
-ARG GRAALVM_PKG=https://github.com/oracle/truffleruby/releases/download/vm-$GRAALVM_VERSION/truffleruby-$GRAALVM_VERSION-GRAALVM_ARCH.tar.gz
+ARG GRAALVM_PKG=https://github.com/oracle/truffleruby/releases/download/graal-$GRAALVM_VERSION/truffleruby-community-$GRAALVM_VERSION-GRAALVM_ARCH.tar.gz
 ARG TEMP_REGION=""
 
 WORKDIR /app

--- a/truffleruby-community/Dockerfile.ol9
+++ b/truffleruby-community/Dockerfile.ol9
@@ -16,7 +16,7 @@ LABEL \
 
 ARG GRAALVM_VERSION=23.0.0
 ARG TARGETPLATFORM
-ARG GRAALVM_PKG=https://github.com/oracle/truffleruby/releases/download/vm-$GRAALVM_VERSION/truffleruby-$GRAALVM_VERSION-GRAALVM_ARCH.tar.gz
+ARG GRAALVM_PKG=https://github.com/oracle/truffleruby/releases/download/graal-$GRAALVM_VERSION/truffleruby-community-$GRAALVM_VERSION-GRAALVM_ARCH.tar.gz
 ARG TEMP_REGION=""
 
 WORKDIR /app

--- a/truffleruby-community/Dockerfile.ol9-slim
+++ b/truffleruby-community/Dockerfile.ol9-slim
@@ -16,7 +16,7 @@ LABEL \
 
 ARG GRAALVM_VERSION=23.0.0
 ARG TARGETPLATFORM
-ARG GRAALVM_PKG=https://github.com/oracle/truffleruby/releases/download/vm-$GRAALVM_VERSION/truffleruby-$GRAALVM_VERSION-GRAALVM_ARCH.tar.gz
+ARG GRAALVM_PKG=https://github.com/oracle/truffleruby/releases/download/graal-$GRAALVM_VERSION/truffleruby-community-$GRAALVM_VERSION-GRAALVM_ARCH.tar.gz
 ARG TEMP_REGION=""
 
 WORKDIR /app


### PR DESCRIPTION
The published images seem OK, I guess because `GRAALVM_PKG` overridden on the command line when building them?

Another option could be to just use `ARG GRAALVM_PKG` without a default, but this seems clearer to explain where the archives come from.

BTW the Dockerfiles for `graalvm-community` seems confusing/messy too, because for instance:
https://github.com/graalvm/container/blob/2a8e138fe0b0200a80a7addddedf186b5ff74192/graalvm-community/Dockerfile.ol9-java20#L26
but there is no `JDK_BUILD` nor `JDK_BUILD_GRAALVM_ARCH_bin` variables, so that default doesn't work.

Also there are still -java17/-java20 dockerfiles but the latest release is 21/22, so they seem outdated.
I guess these dockerfiles could take the Java version as an `ARG` and not duplicate them per Java version.
In general, it would be great if the Dockerfiles in this repo are up-to-date with the images that have been published, it seems not to be the case currently.

cc @fniephaus